### PR TITLE
CS-5753: Wrong error message when sharing a calendar with invalid user name

### DIFF
--- a/eXoApplication/calendar/webapp/src/main/java/org/exoplatform/calendar/webui/popup/UISharedForm.java
+++ b/eXoApplication/calendar/webapp/src/main/java/org/exoplatform/calendar/webui/popup/UISharedForm.java
@@ -202,7 +202,12 @@ public class UISharedForm extends UIForm implements UIPopupComponent, UISelector
           }
         }
         if(sb.length() > 0) {
-          event.getRequestContext().getUIApplication().addMessage(new ApplicationMessage("UISharedForm.msg.not-founduser", new Object[]{sb.toString()}, 1)) ;
+          String invalidNames = sb.toString();
+          if(invalidNames.split(CalendarUtils.COMMA).length == 1) {
+        	  event.getRequestContext().getUIApplication().addMessage(new ApplicationMessage("UISharedForm.msg.not-found-user", new Object[]{invalidNames.substring(0, invalidNames.length() - 1)}, 1)) ;	  
+          } else {
+        	  event.getRequestContext().getUIApplication().addMessage(new ApplicationMessage("UISharedForm.msg.not-found-users", new Object[]{invalidNames.substring(0, invalidNames.length() - 1)}, 1)) ;
+            }
           return ;
         }
         if(receiverUsers.contains(username)) {

--- a/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet.properties
+++ b/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet.properties
@@ -632,6 +632,7 @@ UISharedForm.action.Save=#{word.save}
 UISharedForm.action.Close=#{word.close}
 UISharedForm.action.Cancel=Cancel
 UISharedForm.msg.not-found-user=User {0} was not found, please check again.
+UISharedForm.msg.not-found-users=Users {0} were not found, please check again.
 UISharedForm.msg.found-user=User {0} is the owner of this calendar, it is not necessary to share the calendar with him.
 UISharedForm.msg.required=Who would you like to share to?
 UISharedForm.msg.not-foundgroup=Group {0} was not found, please check again.

--- a/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet_en.properties
+++ b/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet_en.properties
@@ -632,6 +632,7 @@ UISharedForm.action.Save=#{word.save}
 UISharedForm.action.Close=#{word.close}
 UISharedForm.action.Cancel=Cancel
 UISharedForm.msg.not-found-user=User {0} was not found, please check again.
+UISharedForm.msg.not-found-users=Users {0} were not found, please check again.
 UISharedForm.msg.found-user=User {0} is the owner of this calendar, it is not necessary to share the calendar with him.
 UISharedForm.msg.required=Who would you like to share to?
 UISharedForm.msg.not-foundgroup=Group {0} was not found, please check again.


### PR DESCRIPTION
Fix description:
- Correct the resource key invoked in UISharedForm.java
