### PR TITLE
Fix/2.2.x/cs 5810

### DIFF
--- a/component/upgrade/pom.xml
+++ b/component/upgrade/pom.xml
@@ -55,6 +55,7 @@
       <groupId>org.exoplatform.portal</groupId>
       <artifactId>exo.portal.component.common</artifactId>
       <version>${org.exoplatform.portal.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Fix description:
- The scope of exo.portal.component.common needs to be provided. 
