### PR TITLE
CS-5897 Wrong display of settings context menu when there is a lot of ca...

### DIFF
--- a/eXoApplication/calendar/webapp/src/main/webapp/javascript/eXo/calendar/UICalendars.js
+++ b/eXoApplication/calendar/webapp/src/main/webapp/javascript/eXo/calendar/UICalendars.js
@@ -59,11 +59,7 @@ UICalendars.prototype.calendarMenuCallback = function(anchorElm, evt) {
   var calColor = obj.getAttribute("calColor");
   var canEdit = String(obj.getAttribute("canedit")).toLowerCase();
   var UICalendars = eXo.calendar.UICalendars;
-  var menu = UICalendars.currentMenuElm;
-  var contentContainerElm = DOMUtil.findAncestorByClass(anchorElm, "ContentContainer");
-  if (contentContainerElm) {
-    menu.style.top = (eXo.core.Browser.findPosY(menu) - contentContainerElm.scrollTop) + 'px';
-  }
+  var menu = UICalendars.currentMenuElm;  
   try {
     var selectedCategory = (eXo.calendar.UICalendarPortlet.filterSelect) ? eXo.calendar.UICalendarPortlet.filterSelect : null;
     if (selectedCategory) {


### PR DESCRIPTION
...lendars

Fix description: Top position of context menu is already defined in function swapMenu in UICalendarPortlet.js.
But it's re-defined in function calendarMenuCallback of UICalendars.js.
So we need to remove this re-definition of top position of context menu.
