### PR TITLE
CS-5899 [Calendar] Invalid URL in invitation mail for a space's event

### DIFF
--- a/eXoApplication/calendar/webapp/src/main/java/org/exoplatform/calendar/CalendarUtils.java
+++ b/eXoApplication/calendar/webapp/src/main/java/org/exoplatform/calendar/CalendarUtils.java
@@ -551,10 +551,10 @@ public class CalendarUtils {
     if (url.indexOf(portalName) > 0) {
       if(url.indexOf(portalName + "/" + selectedNode) < 0){
         url = url.replaceFirst(portalName, portalName + "/" + selectedNode) ;
-      } 
-    } 
-    selectedNode = portalName + "/" + selectedNode;
-    url = url.substring(0, url.lastIndexOf(selectedNode) + selectedNode.length());
+      }
+      selectedNode = portalName + "/" + selectedNode;
+      url = url.substring(0, url.lastIndexOf(selectedNode) + selectedNode.length());
+    }    
     return url;
   }
 


### PR DESCRIPTION
Fix description: Only update url in case of intranet context in function getCalendarURL.
