### PR TITLE
CS-5902 Remove redundant key in CalendarPortlet.properties

### DIFF
--- a/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet.properties
+++ b/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet.properties
@@ -332,8 +332,7 @@ UIEventForm.label.summary-the-third=the third
 UIEventForm.label.summary-the-fourth=the fourth
 UIEventForm.label.summary-the-last=the last
 
-#CS-5804
-UIParticipantList.status.=  
+UIParticipantList.status.empty=empty  
 UIParticipantList.status.pending=pending
 UIParticipantList.status.yes=yes
 UIParticipantList.status.no=no

--- a/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet_en.properties
+++ b/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet_en.properties
@@ -332,8 +332,7 @@ UIEventForm.label.summary-the-third=the third
 UIEventForm.label.summary-the-fourth=the fourth
 UIEventForm.label.summary-the-last=the last
 
-#CS-5804
-UIParticipantList.status.=  
+UIParticipantList.status.empty=empty 
 UIParticipantList.status.pending=pending
 UIParticipantList.status.yes=yes
 UIParticipantList.status.no=no

--- a/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet_fr.properties
+++ b/eXoApplication/calendar/webapp/src/main/webapp/WEB-INF/classes/locale/portlet/calendar/CalendarPortlet_fr.properties
@@ -330,8 +330,7 @@ UIEventForm.label.summary-the-third=le troisi\u00e8me
 UIEventForm.label.summary-the-fourth=le quatri\u00e8me
 UIEventForm.label.summary-the-last=le dernier
 
-#CS-5804
-UIParticipantList.status.=  
+UIParticipantList.status.empty=empty 
 UIParticipantList.status.pending=en attente
 UIParticipantList.status.yes=oui
 UIParticipantList.status.no=non


### PR DESCRIPTION
Fix description: Change empty status label from "" to "empty"
